### PR TITLE
Enable Community models

### DIFF
--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ class EmbeddingResponse(BaseModel):
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    models[model_name] = SentenceTransformer(model_name)
+    models[model_name] = SentenceTransformer(model_name, trust_remote_code=True)
     yield
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
-sentence-transformers==2.2.2
+sentence-transformers==2.4.0
 uvicorn[standard]
+einops


### PR DESCRIPTION
Hey there,
to be able to use community provided models we need to set `trust_remote_code=True`.

So I update the sentence_transformers package and added einops requirements which was necessary to use the `nomic-ai/nomic-embed-text-v1.5` model for example.

Feel free to integrate if it is helpful :)

Love,
Yannick